### PR TITLE
CC-104-courseDetail-richText

### DIFF
--- a/src/Components/CourseCards/CourseOverview.jsx
+++ b/src/Components/CourseCards/CourseOverview.jsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
 
 const CourseOverview = ({ course }) => {
   return (
     <Box sx={{ mb: 4 }}>
       <Typography variant='h6' paragraph>
-        {course.courseDescription}
+        Course Overview
       </Typography>
-
-      <Typography variant='h6' fontWeight={"bold"}>
-        Extras
-      </Typography>
-      {course.courseExtras.map((extra, i) => {
-        return <Typography key={i}>{extra}</Typography>;
-      })}
+      <ReactQuill
+        value={course.courseDescription} // Pass the course description as value
+        readOnly={true} // Make it read-only so it's non-editable
+        theme='bubble'
+      />
     </Box>
   );
 };


### PR DESCRIPTION
The Course Overview page in the website now shows the rich Text format that was added in the dashboard by the admin.
As shown in the screenshot,

![image](https://github.com/user-attachments/assets/e8e4216c-561f-41cd-bed5-512c2c298920)

Let me know if you need any more info regarding this